### PR TITLE
Fix parsing bare args when the completion handler for '<>' is undef.

### DIFF
--- a/lib/Getopt/Complete/Args.pm
+++ b/lib/Getopt/Complete/Args.pm
@@ -128,7 +128,7 @@ sub _init {
     };
 
     if (@ARGV) {
-        if ($self->options->completion_handler('<>')) {
+        if ($self->options->has_option('<>')) {
             my $a = $values{'<>'} ||= [];
             push @$a, @ARGV;
         }


### PR DESCRIPTION
The bug can be reproduced with the following code:
    use Getopt::Complete (
        '<>' => undef,
       );
    print Dumper($ARGS->bare_args);
the invocation `./program test` yields `undef` instead of `['test']`.
